### PR TITLE
Treat previous run as burnin

### DIFF
--- a/R/AgeS_Computation.R
+++ b/R/AgeS_Computation.R
@@ -371,6 +371,7 @@ AgeS_Computation <- function(
         thin = t,
         method = jags_method,
         silent.jags = quiet,
+        combine = FALSE,
         ...
       )
 

--- a/R/Age_OSLC14.R
+++ b/R/Age_OSLC14.R
@@ -412,6 +412,7 @@ Age_OSLC14 <- function(
         thin = t,
         method = jags_method,
         silent.jags = quiet,
+        combine = FALSE,
         ...
       )
 


### PR DESCRIPTION
I thought that previous runjags-run samples would be treated as burn-in. I miss-read. These corrections will implement so that previous samples are used as burn-in. 